### PR TITLE
Fix dev/docker-compose.yml

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -13,11 +13,13 @@ services:
       file: ../common/docker-compose.yml
       service: configserver
   licensingservice:
-     image: ch3-thoughtmechanix/licensing-service
-     ports:
-       - "8080:8080"
-     environment:
-       PROFILE: "dev"
-       CONFIGSERVER_URI: "http://configserver:8888"
-       CONFIGSERVER_PORT:   "8888"
-       DATABASESERVER_PORT: "5432"
+    extends:
+      file: ../common/docker-compose.yml
+      service: licensingservice
+    ports:
+      - "8080:8080"
+    environment:
+      PROFILE: "dev"
+      CONFIGSERVER_URI: "http://configserver:8888"
+      CONFIGSERVER_PORT:   "8888"
+      DATABASESERVER_PORT: "5432"


### PR DESCRIPTION
Corrected lincensingservice section. The original dev/docker-compose.yml was failing with an error because the image ch3-thoughtmechanix/licensing-service could not be found. The same issue exists with prod/docker-compose.yml. This problem is present in the other chapters as well.